### PR TITLE
:bug: Adjust expire date on change validation

### DIFF
--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -19,8 +19,12 @@ const handleKeyUp = (
 			const year = formattedValue.substr(2, 2);
 
 			if (month && event.data && !isNaN(Number(event.data))) {
-				if (Number(event.data) < 10) {
-					formattedValue = `0${month}`;
+				if (Number(event.data) > 0 && Number(event.data) < 10) {
+					if (month.startsWith('0')) {
+						formattedValue = month;
+					} else {
+						formattedValue = `0${month}`;
+					}
 				}
 
 				const normalizedMonth = `${month.substring(1)}${event.data}`;


### PR DESCRIPTION
## Description

We had an issue with the way that we get the on change for expire date fields because of the mask

## Problem

If you type 2, we automatically set the first 0, but this was misleading when the user sets 0 as first characters, returning 00.

## Solution

If the user types 0 we display only 0, but if the user types 1 or higher we still display 01 to help the user

## Proposed Changes

[List the main changes made in this Pull Request]

- Adjust on change for expire date validation mask

## Tests Performed

[Describe the tests that were executed to validate the changes made]

- [Example 1]
- [Example 2]
- [Example 3]

## Screenshots

[If applicable, add screenshots or gifs to visually demonstrate the changes made]

## Checklist

- [ ] The changes have been tested locally and are functioning correctly
- [ ] Unit tests have been added or updated to reflect the changes
- [ ] Documentation has been updated if necessary
- [ ] All dependencies have been updated and are compatible with the changes
- [ ] The code follows the styling and formatting conventions of the application
- [ ] The Pull Request has a descriptive and informative title
- [ ] The Pull Request is assigned to the responsible person for review
- [ ] All necessary reviewers have been added

## Related Issues

[If there are any issues related to this Pull Request, list them here]

Fixes #[Issue Number]
