### PR TITLE
:bug: Adjust expiration date regex formatter

### DIFF
--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -7,7 +7,7 @@ const handleKeyUp = (
 	{ validationType, maxLength, customHandleChange }: InputChangeProps
 ) => {
 	const target = event.target as HTMLInputElement;
-	let formattedValue = regexOnlyNumbers(target.value);
+	const formattedValue = regexOnlyNumbers(target.value);
 
 	switch (validationType) {
 		case 'holderName': {
@@ -15,36 +15,26 @@ const handleKeyUp = (
 			break;
 		}
 		case 'expirationDate': {
-			let month = formattedValue.substr(0, 2);
-			const year = formattedValue.substr(2, 2);
+			const expDate = formattedValue
+				.replace(
+					/^([2-9])$/g,
+					'0$1' // To handle 3 > 03
+				)
+				.replace(
+					/^(1{1})([3-9]{1})$/g,
+					'0$1/$2' // 13 > 01/3
+				)
+				.replace(
+					/^0{1,}/g,
+					'0' // To handle 00 > 0
+				)
+				.replace(
+					/^([0-1]{1}[0-9]{1})([0-9]{1,2}).*/g,
+					'$1/$2' // To handle 113 > 11/3
+				);
 
-			if (month && event.data && !isNaN(Number(event.data))) {
-				if (Number(event.data) > 0 && Number(event.data) < 10) {
-					if (month.startsWith('0')) {
-						formattedValue = month;
-					} else {
-						formattedValue = `0${month}`;
-					}
-				}
-
-				const normalizedMonth = `${month.substring(1)}${event.data}`;
-				if (month.startsWith('0') && month.length === 2 && Number(normalizedMonth) <= 12) {
-					customHandleChange(normalizedMonth);
-					target.value = normalizedMonth;
-					return;
-				}
-			}
-
-			if (Number(month) > 12) {
-				month = '12';
-			}
-
-			if (year) {
-				formattedValue = `${month}/${year}`;
-			}
-
-			customHandleChange(formattedValue);
-			target.value = formattedValue;
+			customHandleChange(expDate);
+			target.value = expDate;
 			break;
 		}
 		case 'cvv': {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const webpack = require('webpack');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');


### PR DESCRIPTION
## Description

We had to improve our current regex formatter for expiration date because there were some caveats in some use cases.

## Problem

If you enter 01/26 or 0126 then this will appear as 11/26
If you enter 1/26 or 126 then this will appear as 12/6

## Solution

Now we have a better solution with chained regexes to attend multiple scenarios and avoid edge cases.

## Proposed Changes

[List the main changes made in this Pull Request]

- A new regex pattern was implemented to fix expiration date format

## Tests Performed

[Describe the tests that were executed to validate the changes made]

- Fill the expiration date with invalid values, valid values and multiple months/years to check the regex
