### PR TITLE
:sparkles: Refactor expiration date formatter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export default async ({
 			type: 'tel',
 			id: 'pb-cc-exp-date',
 			validationType: 'expirationDate',
+			eventType: 'keyup',
 			customHandleChange: (expDate: string) => {
 				const { isValid, errors } = validateFields({
 					dateValue: expDate

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,7 @@ export type GenerateFieldProps = {
 	validationType?: string;
 	customHandleChange: (value: string) => void;
 	inputAddornment?: string;
+	eventType?: 'keydown' | 'keyup' | 'input';
 };
 
 export type InputChangeProps = {


### PR DESCRIPTION
## Description

I improved the regex a little bit to attend a request to also let the user to insert a "/" manually. We were adding it only automatically before.

## Problem

It was requested to implement a way to include manually a "/" for the expiration date. Currently we only support it automatically after typing the month.

## Solution

A small refactor to the regex pattern to auto include the "/" as it was before, but also give support to insert it manually and also remove it.

## Proposed Changes

[List the main changes made in this Pull Request]

- Refactor substr to substring method since substr will be deprecated
- Refactor to support diferent keyboard event types for future possible modifications without breaking other fields
- Refactor in the regex to support including manual slashes and also removals

## Tests Performed

[Describe the tests that were executed to validate the changes made]

- Type different month/years in the expiration date field.

## Screenshots

[If applicable, add screenshots or gifs to visually demonstrate the changes made]

## Checklist

- [ ] The changes have been tested locally and are functioning correctly
- [ ] Unit tests have been added or updated to reflect the changes
- [ ] Documentation has been updated if necessary
- [ ] All dependencies have been updated and are compatible with the changes
- [ ] The code follows the styling and formatting conventions of the application
- [ ] The Pull Request has a descriptive and informative title
- [ ] The Pull Request is assigned to the responsible person for review
- [ ] All necessary reviewers have been added

## Related Issues

[If there are any issues related to this Pull Request, list them here]

Fixes #[Issue Number]
